### PR TITLE
:sparkles: Feat: Added thumbnail display for all assets with roles:thumbnail

### DIFF
--- a/src/components/DownloadAsset.js
+++ b/src/components/DownloadAsset.js
@@ -6,7 +6,7 @@ import PopupState, { bindTrigger, bindMenu } from 'material-ui-popup-state';
 const DownloadAsset = (props) => {
 
   const canDownload = () => {
-    return props.assets ? true : false
+    return props.assets
   }
   
   if (!props.assets) {
@@ -14,14 +14,15 @@ const DownloadAsset = (props) => {
   }
 
   const items = Object.keys(props.assets)
-  const itemList = items.map( item => {
+  const itemList = items.map( (item, index) => {
+    const title = props.assets[item].title ? props.assets[item].title : props.assets[item].description
     return (
-      props.assets[item].title &&
-      <MenuItem component={Link} href={props.assets[item].href} target="_blank">
+      title &&
+      <MenuItem component={Link} href={props.assets[item].href} target="_blank" key={index}>
         <ListItemIcon>
           <CloudDownloadOutlined />
         </ListItemIcon>
-        <Typography>{props.assets[item].title}</Typography>
+        <Typography>{title}</Typography>
       </MenuItem>
     )
   })

--- a/src/components/ThumbnailPreview.js
+++ b/src/components/ThumbnailPreview.js
@@ -8,22 +8,23 @@ const ThumbnailPreview = (props) => {
 
   const [isOpen, setIsOpen] = useState(false)
 
-  const hasThumbnail = () => {
-    return props.assets.thumbnail ? true : false
-  }
+  const values = Object.values(props.assets)
+  const hasRole = values.find(asset => asset.roles && asset.roles.includes('thumbnail'))
 
   return (
     <>
-      {hasThumbnail() &&
+      {hasRole &&
         <Link href="#" onClick={() => setIsOpen(true)}>
+          {/* <IconButton> */}
             <ImageSearchOutlinedIcon />
+          {/* </IconButton> */}
         </Link>
       }  
 
-      {hasThumbnail && isOpen && 
+      {hasRole && isOpen && 
       <>
         <Lightbox
-          mainSrc={props.assets.thumbnail.href}
+          mainSrc={hasRole.href}
           onCloseRequest={() => setIsOpen(false)}
         />
       </>


### PR DESCRIPTION
Thumbnails now generated by asset.roles['thumbnail'] rather than asset.thumbnail.
Also added key to asset list for dropdown